### PR TITLE
[agent] pass the most recent revision through atomic value

### DIFF
--- a/cmd/ep-agent/main.go
+++ b/cmd/ep-agent/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	agent := agent.Agent{Client: etcd, Syncer: sc}
 
-	updateCh := make(chan int64, 1)
+	updateCh := make(chan struct{}, 1)
 	cmd.Go(func(ctx context.Context) error {
 		return agent.StartWatching(ctx, updateCh)
 	})

--- a/constants.go
+++ b/constants.go
@@ -5,11 +5,11 @@ const (
 	KeyConfig        = "config"
 	KeyLastUID       = "last-uid"
 	KeyLastGID       = "last-gid"
-	KeyUsers         = "users"
-	KeyDeletedUsers  = "deleted-users"
-	KeyGroups        = "groups"
-	KeyDeletedGroups = "deleted-groups"
-	KeyLocked        = "locked"
+	KeyUsers         = "users/"
+	KeyDeletedUsers  = "deleted-users/"
+	KeyGroups        = "groups/"
+	KeyDeletedGroups = "deleted-groups/"
+	KeyLocked        = "locked/"
 )
 
 const (

--- a/database.go
+++ b/database.go
@@ -22,7 +22,7 @@ type Database struct {
 func GetDatabase(ctx context.Context, etcd *clientv3.Client, rev int64) (*Database, error) {
 	db := new(Database)
 
-	resp, err := etcd.Get(ctx, KeyUsers+"/",
+	resp, err := etcd.Get(ctx, KeyUsers,
 		clientv3.WithPrefix(),
 		clientv3.WithRev(rev),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
@@ -42,8 +42,7 @@ func GetDatabase(ctx context.Context, etcd *clientv3.Client, rev int64) (*Databa
 		db.Users = users
 	}
 
-	gprefix := KeyGroups + "/"
-	resp, err = etcd.Get(ctx, gprefix,
+	resp, err = etcd.Get(ctx, KeyGroups,
 		clientv3.WithPrefix(),
 		clientv3.WithRev(rev),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
@@ -53,7 +52,7 @@ func GetDatabase(ctx context.Context, etcd *clientv3.Client, rev int64) (*Databa
 	if resp.Count > 0 {
 		groups := make([]Group, resp.Count)
 		for i, kv := range resp.Kvs {
-			name := string(kv.Key[len(gprefix):])
+			name := string(kv.Key[len(KeyGroups):])
 			gid, err := strconv.Atoi(string(kv.Value))
 			if err != nil {
 				return nil, err
@@ -82,19 +81,19 @@ func GetDatabase(ctx context.Context, etcd *clientv3.Client, rev int64) (*Databa
 		return ret, nil
 	}
 
-	delus, err := getKeys(KeyDeletedUsers + "/")
+	delus, err := getKeys(KeyDeletedUsers)
 	if err != nil {
 		return nil, err
 	}
 	db.DeletedUsers = delus
 
-	delgs, err := getKeys(KeyDeletedGroups + "/")
+	delgs, err := getKeys(KeyDeletedGroups)
 	if err != nil {
 		return nil, err
 	}
 	db.DeletedGroups = delgs
 
-	locked, err := getKeys(KeyLocked + "/")
+	locked, err := getKeys(KeyLocked)
 	if err != nil {
 		return nil, err
 	}

--- a/database_test.go
+++ b/database_test.go
@@ -2,7 +2,6 @@ package etcdpasswd
 
 import (
 	"context"
-	"path"
 	"testing"
 )
 
@@ -39,15 +38,15 @@ func testPrepareDatabase(ctx context.Context, t *testing.T, client Client) int64
 		t.Fatal(err)
 	}
 
-	_, err = client.Put(ctx, path.Join(KeyDeletedUsers, "user3"), "")
+	_, err = client.Put(ctx, KeyDeletedUsers+"user3", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.Put(ctx, path.Join(KeyDeletedGroups, "group2"), "")
+	_, err = client.Put(ctx, KeyDeletedGroups+"group2", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := client.Put(ctx, path.Join(KeyLocked, "user4"), "")
+	resp, err := client.Put(ctx, KeyLocked+"user4", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/group.go
+++ b/group.go
@@ -3,7 +3,6 @@ package etcdpasswd
 import (
 	"context"
 	"errors"
-	"path"
 	"strconv"
 
 	"github.com/coreos/etcd/clientv3"
@@ -19,7 +18,7 @@ type Group struct {
 // ListGroups lists all groups registered in the database.
 // The result is sorted alphabetically.
 func (c Client) ListGroups(ctx context.Context) ([]Group, error) {
-	prefix := KeyGroups + "/"
+	prefix := KeyGroups
 	resp, err := c.Get(ctx, prefix, clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 	if err != nil {
@@ -53,8 +52,8 @@ func (c Client) AddGroup(ctx context.Context, name string) error {
 		return errors.New("invalid group name: " + name)
 	}
 
-	key := path.Join(KeyGroups, name)
-	delKey := path.Join(KeyDeletedGroups, name)
+	key := KeyGroups + name
+	delKey := KeyDeletedGroups + name
 
 RETRY:
 	gid, rev, err := c.getLastID(ctx, KeyLastGID, cfg.StartGID)
@@ -96,8 +95,8 @@ RETRY:
 // RemoveGroup removes an existing managed group.
 // If the group does not exist, ErrNotFound will be returned.
 func (c Client) RemoveGroup(ctx context.Context, name string) error {
-	key := path.Join(KeyGroups, name)
-	delKey := path.Join(KeyDeletedGroups, name)
+	key := KeyGroups + name
+	delKey := KeyDeletedGroups + name
 
 	resp, err := c.Txn(ctx).
 		If(clientv3util.KeyExists(key)).

--- a/group_test.go
+++ b/group_test.go
@@ -2,7 +2,6 @@ package etcdpasswd
 
 import (
 	"context"
-	"path"
 	"reflect"
 	"testing"
 
@@ -11,19 +10,19 @@ import (
 
 func testGroupPrepare(t *testing.T, client Client) {
 	ctx := context.Background()
-	_, err := client.Put(ctx, path.Join(KeyGroups, "test1"), "12345")
+	_, err := client.Put(ctx, KeyGroups+"test1", "12345")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.Put(ctx, path.Join(KeyGroups, "test2"), "12346")
+	_, err = client.Put(ctx, KeyGroups+"test2", "12346")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.Put(ctx, path.Join(KeyGroups, "abc"), "12347")
+	_, err = client.Put(ctx, KeyGroups+"abc", "12347")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.Put(ctx, path.Join(KeyDeletedGroups, "test0"), "12344")
+	_, err = client.Put(ctx, KeyDeletedGroups+"test0", "12344")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +81,7 @@ func testGroupAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	delKey := path.Join(KeyDeletedGroups, "test0")
+	delKey := KeyDeletedGroups + "test0"
 	resp, err := client.Get(ctx, delKey, clientv3.WithCountOnly())
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +89,7 @@ func testGroupAdd(t *testing.T) {
 	if resp.Count != 0 {
 		t.Error(`resp.Count != 0`, resp.Count)
 	}
-	resp2, err := client.Get(ctx, path.Join(KeyGroups, "test0"))
+	resp2, err := client.Get(ctx, KeyGroups+"test0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +104,7 @@ func testGroupAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp3, err := client.Get(ctx, path.Join(KeyGroups, "zzz"))
+	resp3, err := client.Get(ctx, KeyGroups+"zzz")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +135,7 @@ func testGroupRemove(t *testing.T) {
 		t.Error(err)
 	}
 
-	delKey := path.Join(KeyDeletedGroups, "test1")
+	delKey := KeyDeletedGroups + "test1"
 	resp, _ := client.Get(ctx, delKey, clientv3.WithCountOnly())
 	if resp.Count != 1 {
 		t.Error(`deleted group should have been registered`)

--- a/lock.go
+++ b/lock.go
@@ -3,13 +3,12 @@ package etcdpasswd
 import (
 	"context"
 	"errors"
-	"path"
 )
 
 // ListLocked lists all password-locked users.
 // The result is sorted alphabetically.
 func (c Client) ListLocked(ctx context.Context) ([]string, error) {
-	return c.list(ctx, KeyLocked+"/")
+	return c.list(ctx, KeyLocked)
 }
 
 // Lock adds name to locked user database on etcd.
@@ -17,7 +16,7 @@ func (c Client) Lock(ctx context.Context, name string) error {
 	if !IsValidUserName(name) {
 		return errors.New("invalid user name: " + name)
 	}
-	key := path.Join(KeyLocked, name)
+	key := KeyLocked + name
 
 	_, err := c.Put(ctx, key, "")
 	return err
@@ -25,7 +24,7 @@ func (c Client) Lock(ctx context.Context, name string) error {
 
 // Unlock removes name from locked user database on etcd.
 func (c Client) Unlock(ctx context.Context, name string) error {
-	key := path.Join(KeyLocked, name)
+	key := KeyLocked + name
 
 	_, err := c.Delete(ctx, key)
 	return err

--- a/lock_test.go
+++ b/lock_test.go
@@ -2,7 +2,6 @@ package etcdpasswd
 
 import (
 	"context"
-	"path"
 	"testing"
 
 	"github.com/coreos/etcd/clientv3"
@@ -25,7 +24,7 @@ func TestLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, err := client.Get(ctx, path.Join(KeyLocked, "cybozu"), clientv3.WithCountOnly())
+	resp, err := client.Get(ctx, KeyLocked+"cybozu", clientv3.WithCountOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +50,7 @@ func TestUnlock(t *testing.T) {
 		t.Error("failed to unlock non-locked user")
 	}
 
-	_, err = client.Put(ctx, path.Join(KeyLocked, "cybozu"), "")
+	_, err = client.Put(ctx, KeyLocked+"cybozu", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +60,7 @@ func TestUnlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, err := client.Get(ctx, path.Join(KeyLocked, "cybozu"), clientv3.WithCountOnly())
+	resp, err := client.Get(ctx, KeyLocked+"cybozu", clientv3.WithCountOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/user.go
+++ b/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"path"
 	"strconv"
 
 	"github.com/coreos/etcd/clientv3"
@@ -40,13 +39,13 @@ func (u *User) Validate() error {
 // ListUsers lists all user names registered in the database.
 // The result is sorted alphabetically.
 func (c Client) ListUsers(ctx context.Context) ([]string, error) {
-	return c.list(ctx, KeyUsers+"/")
+	return c.list(ctx, KeyUsers)
 }
 
 // GetUser looks up named user from the database.
 // If the user is not found, this returns ErrNotFound.
 func (c Client) GetUser(ctx context.Context, name string) (*User, int64, error) {
-	key := path.Join(KeyUsers, name)
+	key := KeyUsers + name
 
 	resp, err := c.Get(ctx, key)
 	if err != nil {
@@ -92,8 +91,8 @@ func (c Client) AddUser(ctx context.Context, user *User) error {
 		return err
 	}
 
-	key := path.Join(KeyUsers, user.Name)
-	delKey := path.Join(KeyDeletedUsers, user.Name)
+	key := KeyUsers + user.Name
+	delKey := KeyDeletedUsers + user.Name
 
 RETRY:
 	uid, rev, err := c.getLastID(ctx, KeyLastUID, cfg.StartUID)
@@ -145,7 +144,7 @@ func (c Client) UpdateUser(ctx context.Context, user *User, rev int64) error {
 		return err
 	}
 
-	key := path.Join(KeyUsers, user.Name)
+	key := KeyUsers + user.Name
 	j, err := json.Marshal(user)
 	if err != nil {
 		return err
@@ -170,8 +169,8 @@ func (c Client) UpdateUser(ctx context.Context, user *User, rev int64) error {
 // RemoveUser removes an existing managed user.
 // If the user does not exist, ErrNotFound will be returned.
 func (c Client) RemoveUser(ctx context.Context, name string) error {
-	key := path.Join(KeyUsers, name)
-	delKey := path.Join(KeyDeletedUsers, name)
+	key := KeyUsers + name
+	delKey := KeyDeletedUsers + name
 
 	resp, err := c.Txn(ctx).
 		If(clientv3util.KeyExists(key)).

--- a/user_test.go
+++ b/user_test.go
@@ -2,7 +2,6 @@ package etcdpasswd
 
 import (
 	"context"
-	"path"
 	"reflect"
 	"testing"
 
@@ -51,7 +50,7 @@ func testUserGet(t *testing.T) {
 		t.Error("user cybozu should not be found")
 	}
 
-	key := path.Join(KeyUsers, "cybozu")
+	key := KeyUsers + "cybozu"
 	_, err = client.Put(ctx, key, testUserData)
 	if err != nil {
 		t.Fatal(err)
@@ -148,7 +147,7 @@ func testUserAdd(t *testing.T) {
 		t.Error(`gu.Shell != "/bin/zsh"`)
 	}
 
-	delKey := path.Join(KeyDeletedUsers, "cybozu3")
+	delKey := KeyDeletedUsers + "cybozu3"
 	_, err = client.Put(ctx, delKey, "")
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +192,7 @@ func testUserUpdate(t *testing.T) {
 	client := newTestClient(t)
 	defer client.Close()
 
-	key := path.Join(KeyUsers, "cybozu")
+	key := KeyUsers + "cybozu"
 	_, err := client.Put(ctx, key, testUserData)
 	if err != nil {
 		t.Fatal(err)
@@ -260,7 +259,7 @@ func testUserRemove(t *testing.T) {
 		t.Fatal("non-existing user should not be removed")
 	}
 
-	key := path.Join(KeyUsers, "cybozu")
+	key := KeyUsers + "cybozu"
 	_, err = client.Put(ctx, key, testUserData)
 	if err != nil {
 		t.Fatal(err)
@@ -271,7 +270,7 @@ func testUserRemove(t *testing.T) {
 		t.Error(err)
 	}
 
-	delKey := path.Join(KeyDeletedUsers, "cybozu")
+	delKey := KeyDeletedUsers + "cybozu"
 	resp, _ := client.Get(ctx, delKey, clientv3.WithCountOnly())
 	if resp.Count != 1 {
 		t.Error(`deleted user should have been registered`)


### PR DESCRIPTION
Before this commit, the watcher passes the revision to the updater
through a buffered channel.  If the channel overflows, the updater
sees an old revision.  As a result, the most up-to-date changes
would not be reflected soon in some cases.

This commit changes how to pass the database revision.
The revision is now stored/load atomically through a variable.
The watcher stores the latest revision to the variable and just
notify the updater via channel.

--
This PR includes another commit to remove `path.Join`.