### PR TITLE
Fix release workflow to run on git repository

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -100,6 +100,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: mkdir -p /tmp/upload
       - name: Download etcdpasswd deb package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix release workflow in [#103](https://github.com/cybozu-go/etcdpasswd/pull/103)
+
 ## [1.4.14] - 2026-09-08
 
 ### Changed


### PR DESCRIPTION
The `gh` command requires any one of a `GH_REPO` environment variable,
a `--repo` option, or a local git repository.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
See-also: https://github.com/cybozu-go/sabakan/pull/288
