### PR TITLE
ci: declare GITHUB_TOKEN permissions in the main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,8 @@ on:
       - 'v*'
 env:
   filename: "main.yaml"
+permissions:
+  contents: read
 jobs:
   build:
     name: Build
@@ -99,6 +101,8 @@ jobs:
     needs: mtest
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write # gh release create
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: mkdir -p /tmp/upload


### PR DESCRIPTION
## What

Declare `GITHUB_TOKEN` permissions in `.github/workflows/main.yaml`:

| job | permissions | reason |
|---|---|---|
| (top-level) | `contents: read` | default for every job in the workflow |
| `build` | inherits read | checkout, `make test`, `make deb`, `upload-artifact` |
| `mtest` | inherits read | GCP auth uses `credentials_json` (a service account key, not OIDC), Slack notification uses a webhook secret |
| `release` | `contents: write` | `gh release create` with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` |

## Why

This repository's default workflow permissions are `write`, and none of the jobs declared `permissions`, so every PR and push run received a `GITHUB_TOKEN` with write access to contents, packages, issues and pull requests. Only the `release` job (tag push) actually writes to GitHub, and it only needs `contents: write`.


## Verification

- YAML parsed with PyYAML.
- No step in `build` / `mtest`, nor the Makefile targets and `mtest/` scripts they call, references `GITHUB_TOKEN`.
- The `release` job keeps the same effective permission it uses today (`contents: write`), so tag releases are unaffected.
